### PR TITLE
Add default export.

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,10 +71,7 @@ class CopyButtonPlugin {
   }
 }
 
-// Check if the NodeJS environment is available before exporting the class
-if (typeof module != "undefined") {
-  module.exports = CopyButtonPlugin;
-}
+export default CopyButtonPlugin
 
 /**
  * Basic support for localization. Please submit a PR


### PR DESCRIPTION
Instead of checking if a Node.js environment is available, simply provide a default export. Allows the ES6 module to be imported by another JS file, e.g. in a web application.